### PR TITLE
Optimization: remove redundant SpriteBatch.Begin()

### DIFF
--- a/src/MysteryIsland/Screens/GameScreen.cs
+++ b/src/MysteryIsland/Screens/GameScreen.cs
@@ -45,14 +45,10 @@ public class GameScreen : IScreen, IDisposable
 
         if (world.IsReady)
         {
-            world.Draw();
-
-            // TODO: draw this from within the world... or something of that sort
-            // to get rid of this extra spritebatch.Begin
-            using var samplerState = new SamplerState { Filter = TextureFilter.Point };
-            SpriteBatch.Begin(transformMatrix: world.Camera.GetViewMatrix(), samplerState: samplerState);
-            debugOverlay.DrawOnMap(SpriteBatch);
-            SpriteBatch.End();
+            world.Draw((sb) =>
+            {
+                debugOverlay.DrawOnMap(SpriteBatch);
+            });
         }
 
         SpriteBatch.Begin();

--- a/src/MysteryIsland/World/GameWorld.cs
+++ b/src/MysteryIsland/World/GameWorld.cs
@@ -74,7 +74,7 @@ public class GameWorld : IDisposable
         collisionComponent.Update(gameTime);
     }
 
-    public void Draw()
+    public void Draw(Action<SpriteBatch> draw)
     {
         if (!IsReady) return;
 
@@ -83,6 +83,7 @@ public class GameWorld : IDisposable
         using var samplerState = new SamplerState { Filter = TextureFilter.Point };
         SpriteBatch.Begin(transformMatrix: Camera.GetViewMatrix(), samplerState: samplerState);
         Character.Draw(SpriteBatch);
+        draw(SpriteBatch);
         SpriteBatch.End();
 
         Map.DrawLayersAboveCharacter(Camera);

--- a/src/MysteryIsland/World/Map.cs
+++ b/src/MysteryIsland/World/Map.cs
@@ -86,8 +86,7 @@ public class Map : IDisposable
         if (map is null) throw new MapNotLoadedException();
         if (mapRenderer is null) return;
 
-        var layersToRender = map.TileLayers.Where(l => shouldRender(l));
-        foreach (var layer in layersToRender) mapRenderer.Draw(layer, camera.GetViewMatrix());
+        foreach (var layer in map.TileLayers.Where(shouldRender)) mapRenderer.Draw(layer, camera.GetViewMatrix());
 
         bool shouldRender(TiledMapLayer layer)
         {


### PR DESCRIPTION
- Remove redundant spritebatch.begin()
- Do not enumerate tilelayers multiple times
